### PR TITLE
make header configurable

### DIFF
--- a/documentedlist.py
+++ b/documentedlist.py
@@ -1,4 +1,5 @@
 
+import shlex
 from docutils import nodes
 from docutils.parsers.rst import directives
 from docutils.parsers.rst.directives.tables import Table
@@ -6,7 +7,8 @@ from docutils.parsers.rst.directives.tables import Table
 
 class DocumentedListDirective(Table):
 
-    option_spec = {'listobject': directives.unchanged}
+    option_spec = {'listobject': directives.unchanged,
+                   'header': directives.unchanged}
 
     def run(self):
         if self.content:
@@ -42,7 +44,7 @@ class DocumentedListDirective(Table):
             )
             return [error]
 
-        table_headers = ['Item', 'Description']
+        table_headers = shlex.split(self.options.get('header', 'Item Description'))
         table_body = member
         max_cols = len(table_headers)
 


### PR DESCRIPTION
Hi! Thanks for the great sphinx extension. I needed a way to configure the header and the number of columns, so here's the PR! :smiley:

example.rst

``` rst
.. documentedlist::
    :listobject: foo.lst
    :header: Surname "Given Name" Email
```

foo.py

``` python
lst = [
    ["John", "Doe", "john@example.com"]
]
```

Result

| Surname | Given Name | Email |
| --- | --- | --- |
| John | Doe | john@example.com |
