### PR TITLE
fix docutils 0.13.1 compat

### DIFF
--- a/sphinxcontrib/documentedlist.py
+++ b/sphinxcontrib/documentedlist.py
@@ -65,7 +65,7 @@ class DocumentedListDirective(Table):
         self.spantolast = 'spantolast' in self.options
         self.headers = shlex.split(self.options.get('header', 'Item Description'))
         self.max_cols = len(self.headers)
-        self.col_widths = self.get_column_widths(self.max_cols)
+        _, self.col_widths = self.get_column_widths(self.max_cols)
 
         table_body = member
         title, messages = self.make_title()


### PR DESCRIPTION
[This change](https://sourceforge.net/p/docutils/code/7785/) in docutils 0.13.1 makes [`self.get_column_widths(self.max_cols)`](https://github.com/chintal/sphinxcontrib-documentedlist/blob/7a39c180604a6095d5096c621d11f4fc5460f978/sphinxcontrib/documentedlist.py#L68) in documentedlist fail, as evidenced here: https://travis-ci.org/mitmproxy/mitmproxy/jobs/182631488#L255.

Without really looking into it, just discarding the new part of the return value solves the issue for me and renders a proper table.